### PR TITLE
#166021182 Create API endpoint for admin to delete an ad

### DIFF
--- a/server/controllers/car.js
+++ b/server/controllers/car.js
@@ -97,3 +97,16 @@ export const getAvailableCars = (req, res) => {
         data: cars
     });
 };
+
+export const deleteAd = (req, res) => {
+    const { carId } = req.body;
+    const { isAdmin } = getUserFromToken(req.headers.authorization);
+    if (!isAdmin) return errorMessage(res, 403, 'You do not have access to this resource');
+    const car = carQueries.findCarById(carId);
+    if (!car) return errorMessage(res, 404, 'Car not found');
+    carQueries.deleteCar(car);
+    return res.status(200).json({
+        status: 'success',
+        message: 'Car Ad successfully deleted'
+    });
+};

--- a/server/helpers/queries.js
+++ b/server/helpers/queries.js
@@ -52,6 +52,13 @@ export const carQueries = {
     updateEntity(newCarObject) {
         const carIndex = cars.indexOf(newCarObject);
         cars.splice(carIndex, 1, newCarObject);
+    },
+
+    deleteCar(carObject) {
+        const carIndex = cars.indexOf(carObject);
+        cars.splice(carIndex, 1);
+        // returns true if car has been deleted and false if it hasn't
+        return !cars.indexOf(carObject);
     }
 };
 

--- a/server/middleware/vaidators/car.js
+++ b/server/middleware/vaidators/car.js
@@ -113,3 +113,4 @@ export const validatePostCar = [
 export const validatePatchStatus = validateIdParam;
 export const validatePatchPrice = [validateIdParam, validatePrice];
 export const validateGetCar = validateIdParam;
+export const validateDeleteCar = validateIdParam;

--- a/server/routes/car.js
+++ b/server/routes/car.js
@@ -6,14 +6,16 @@ import {
     validatePostCar,
     validatePatchStatus,
     validatePatchPrice,
-    validateGetCar
+    validateGetCar,
+    validateDeleteCar
 } from '../middleware/vaidators/car';
 import {
     postCarAd,
     updateStatus,
     updatePrice,
     getSpecificCar,
-    getAvailableCars
+    getAvailableCars,
+    deleteAd
 } from '../controllers/car';
 
 
@@ -31,5 +33,6 @@ router.get('/car', getAvailableCars);
 router.patch('/car/:carId/status', verifyToken, validatePatchStatus, updateStatus);
 router.patch('/car/:carId/price', verifyToken, validatePatchPrice, updatePrice);
 router.get('/car/:carId', validateGetCar, getSpecificCar);
+router.delete('/car/:carId', verifyToken, validateDeleteCar, deleteAd);
 
 export default router;

--- a/server/test/controllerTest/car.test.js
+++ b/server/test/controllerTest/car.test.js
@@ -1006,7 +1006,7 @@ describe('DELETE /api/v1/car/:carId', () => {
 
     it('should return a 200 status if car was successfully deleted', (done) => {
         chai.request(app)
-            .delete('/api/v1/car/3')
+            .delete('/api/v1/car/6')
             .set('Authorization', adminToken)
             .end((error, res) => {
                 if (error) done(error);

--- a/server/test/controllerTest/car.test.js
+++ b/server/test/controllerTest/car.test.js
@@ -947,7 +947,7 @@ describe('GET /api/v1/car?status=available&min_price=XXXvalue&max_price=XXXvalue
     });
 });
 
-describe.only('DELETE /api/v1/car/:carId', () => {
+describe('DELETE /api/v1/car/:carId', () => {
     before((done) => {
         chai.request(app)
             .post('/api/v1/auth/signin')

--- a/server/test/controllerTest/car.test.js
+++ b/server/test/controllerTest/car.test.js
@@ -8,6 +8,7 @@ const { expect } = chai;
 chai.use(chaiHttp);
 
 let myToken;
+let adminToken;
 
 before((done) => {
     chai.request(app)
@@ -941,6 +942,78 @@ describe('GET /api/v1/car?status=available&min_price=XXXvalue&max_price=XXXvalue
                 expect(res.body.status).to.deep.equal('success');
                 expect(res.body.data[0]).to.have
                     .keys('id', 'owner', 'state', 'status', 'price', 'manufacturer', 'model', 'bodyType', 'imageUrl', 'createdOn');
+                done();
+            });
+    });
+});
+
+describe.only('DELETE /api/v1/car/:carId', () => {
+    before((done) => {
+        chai.request(app)
+            .post('/api/v1/auth/signin')
+            .send({
+                email: 'johndoe@gmail.com',
+                password: 'pass'
+            })
+            .end((error, res) => {
+                if (error) done(error);
+                adminToken = res.body.data.token;
+                done();
+            });
+    });
+
+    it('should return a 403 status if user is not an admin', (done) => {
+        chai.request(app)
+            .delete('/api/v1/car/3')
+            .set('Authorization', myToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(403);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('You do not have access to this resource');
+                done();
+            });
+    });
+
+    it('should return a 404 status if car does not exist', (done) => {
+        chai.request(app)
+            .delete('/api/v1/car/39999')
+            .set('Authorization', adminToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(404);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Car not found');
+                done();
+            });
+    });
+
+    it('should return a 404 status if carId is not an integer', (done) => {
+        chai.request(app)
+            .delete('/api/v1/car/string')
+            .set('Authorization', adminToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(404);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Car not found');
+                done();
+            });
+    });
+
+    it('should return a 200 status if car was successfully deleted', (done) => {
+        chai.request(app)
+            .delete('/api/v1/car/3')
+            .set('Authorization', adminToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(200);
+                expect(res.body.status).to.deep.equal('success');
+                expect(res.body.message).to.deep.equal('Car Ad successfully deleted');
                 done();
             });
     });


### PR DESCRIPTION
### What does this PR do?
- Creates the API endpoint `DELETE /api/v1/car/:carId` to delete an advertisement.

### Description of tasks to be completed
- Test API endpoint
- Write controller logic to delete a particular car advertisement

### How should this be manually tested?
- Clone or download this repository
- Run `git checkout ft-api-delete-ad-166021182`
##### To test just this api and other endpoints associated with the car's api,
- Run `mocha ./server/test/controllerTest/car.test.js --require @babel/polyfill --require babel/register  --no-timeout --exit`
##### To test the entire app,
- Run `npm test`

#### Testing API with Postman
- Clone or download this repository
- Run `git checkout ft-api-delete-ad-166021182`
- Run `npm run dev-start`
- Send a `GET` request to `/localhost:3000/api/v1/car/2`
- Adjust car id to test multiple times

### Any background context you want to provide?
- You need admin privilege to test this application on Postman.
   - send a `POST` request to `localhost:3000/api/v1/auth/sign` using the following credentials:
       - `email: 'johndoe@gmail.com'`
       - `password: 'pass'`
   - A token will be generated and send via the response data.
   - Set the `Authorization` header of the `DELETE` request to  `/localhost:3000/api/v1/car/2`

### What are the relevant Pivotal Tracker stories?
-  [#166021182](https://www.pivotaltracker.com/story/show/166021182)