### PR TITLE
#166718217 Create API endpoint to mark advertisements as "sold"

### DIFF
--- a/server/controllers/car.js
+++ b/server/controllers/car.js
@@ -1,7 +1,7 @@
 import { carQueries } from '../models/db/queries';
 import errorMessage from '../helpers/responseMessages';
 
-const postCarAd = async (req, res) => {
+export const postCarAd = async (req, res) => {
     const {
         userId: owner,
         price,
@@ -32,4 +32,20 @@ const postCarAd = async (req, res) => {
     }
 };
 
-export default postCarAd;
+export const updateStatus = async (req, res) => {
+    const { userId } = req.body;
+    const { carId } = req.params;
+    try {
+        const car = await carQueries.findCarById(carId);
+        if (!car || car.owner !== userId) {
+            return errorMessage(res, 404, 'car not found');
+        }
+        const updatedCar = await carQueries.markAsSold(carId);
+        return res.status(200).json({
+            status: 'success',
+            data: updatedCar
+        });
+    } catch (error) {
+        return errorMessage(res, 500, 'oops! somwthingssssss went wrong');
+    }
+};

--- a/server/models/db/queries.js
+++ b/server/models/db/queries.js
@@ -46,6 +46,18 @@ export const carQueries = {
 
         const { rows } = await pool.query(queryString);
         return rows[0];
+    },
+
+    async markAsSold(carId) {
+        const queryString = {
+            text: ` UPDATE cars SET status = $2
+                    WHERE car_id  = $1
+                    RETURNING * ;`,
+            values: [carId, 'sold']
+        };
+
+        const { rows } = await pool.query(queryString);
+        return rows[0];
     }
 };
 

--- a/server/routes/car.js
+++ b/server/routes/car.js
@@ -2,8 +2,8 @@ import express from 'express';
 import { verifyToken } from '../middleware/jwtAuth';
 import upload from '../config/multer.config';
 import imageUploader from '../middleware/imageUploader';
-import { validatePostCar } from '../middleware/vaidators/car';
-import postCarAd from '../controllers/car';
+import { validatePostCar, validatePatchStatus } from '../middleware/vaidators/car';
+import { postCarAd, updateStatus } from '../controllers/car';
 
 
 const router = express.Router();
@@ -15,5 +15,8 @@ router.post('/car',
     validatePostCar,
     imageUploader,
     postCarAd);
+
+router.patch('/car/:carId/status', verifyToken, validatePatchStatus, updateStatus);
+
 
 export default router;

--- a/server/test/controllerTest/car.test.js
+++ b/server/test/controllerTest/car.test.js
@@ -479,3 +479,65 @@ describe('POST /api/v2/car', () => {
             });
     });
 });
+
+describe('PATCH /api/v2/car/:carId/status', () => {
+    it('should return a 404 error if car does not exist', (done) => {
+        chai.request(app)
+            .patch('/api/v2/car/300000000/status')
+            .set('Authorization', myToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(404);
+                expect(res.body).to.have.keys('status', 'message');
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('car not found');
+                done();
+            });
+    });
+
+    it('should return a 404 error if user tries to update a car that is not his', (done) => {
+        chai.request(app)
+            .patch('/api/v2/car/1/status')
+            .set('Authorization', myToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(404);
+                expect(res.body).to.have.keys('status', 'message');
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('car not found');
+                done();
+            });
+    });
+
+    it('should return a 422 error if car id is not an integer', (done) => {
+        chai.request(app)
+            .patch('/api/v2/car/notcar/status')
+            .set('Authorization', myToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body).to.have.keys('status', 'message');
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('invalid car id');
+                done();
+            });
+    });
+
+    it('should return a 200 status if car status was successfully updated', (done) => {
+        chai.request(app)
+            .patch('/api/v2/car/2/status')
+            .set('Authorization', myToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(200);
+                expect(res.body).to.have.keys('status', 'data');
+                expect(res.body.status).to.deep.equal('success');
+                expect(res.body.data.status).to.deep.equal('sold');
+                done();
+            });
+    });
+});


### PR DESCRIPTION
### What does this PR do?
- Creates API endpoint `PATCH /api/v2/car/:carId/status` to mark advertisements  as "sold"
### Description of tasks to be completed
- Test API endpoint
- Write controller logic to update purchase orders

### How should this be manually tested?
- Clone or download this repository
- Run `git checkout ft-apiv2-mark-ad-166718217`
##### To test just this api and other endpoints associated with cars, run:
```
npm run db:populate && mocha ./server/test/controllerTest/car.test.js --require @babel/polyfill --require babel/register  --no-timeout --exit
```
##### To test the entire app,
- Run `npm test`

#### Testing API with Postman
- Clone or download this repository
- Run `git checkout ft-apiv2-mark-ad-166718217`
- Run `npm run dev-start`
- Send a `PATCH` request to `/localhost:3000/api/v2/car/2/status`

### Any background context you want to provide?
- You need to be logged in to test this API using postman. To login,
   - send a `POST` request to `localhost:3000/api/v2/auth/sign` using the following credentials:
```
{
  "email": "ricardokaka@gmail.com",
  "password": "pass"
}
```
   - A token will be generated and send via the response data.
   - Set the `Authorization` header of the PATCH request to  `/localhost:3000/api/v1/car/2/status` 

### What are the relevant Pivotal Tracker stories?
-  [#166718217](https://www.pivotaltracker.com/story/show/166718217)