### PR TITLE
#166718236 Create API endpoint to flag an ad as fraudulent

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ import stringFormater from './server/middleware/stringFormater';
 import userRouter from './server/routes/user';
 import carRouter from './server/routes/car';
 import orderRouter from './server/routes/order';
+import flagRouter from './server/routes/flag';
 
 const app = express();
 
@@ -21,7 +22,7 @@ app.get('/docs', (req, res) => {
         .sendFile(path.resolve('documentation.html'));
 });
 
-app.use('/api/v2/', userRouter, carRouter, orderRouter);
+app.use('/api/v2/', userRouter, carRouter, orderRouter, flagRouter);
 
 app.all('/*', (req, res) => {
     res.status(404).json({

--- a/server/controllers/flag.js
+++ b/server/controllers/flag.js
@@ -1,0 +1,24 @@
+import { createFlag, carQueries } from '../models/db/queries';
+import errorMessage from '../helpers/responseMessages';
+
+const flagAd = async (req, res) => {
+    const {
+        carId,
+        reason,
+        description,
+        userId: reportedBy
+    } = req.body;
+    try {
+        const car = await carQueries.findCarById(carId);
+        if (!car) return errorMessage(res, 404, 'car not found');
+        const newFlag = await createFlag(carId, reason, description, reportedBy);
+        return res.status(201).json({
+            status: 'success',
+            data: newFlag
+        });
+    } catch (error) {
+        return errorMessage(res, 500, 'oops! something went wrong');
+    }
+};
+
+export default flagAd;

--- a/server/middleware/vaidators/flag.js
+++ b/server/middleware/vaidators/flag.js
@@ -23,9 +23,10 @@ const validateDescription = (req, res, next) => {
 const validateCarId = (req, res, next) => {
     const { carId } = req.body;
     if (!carId) return errorMessage(res, 422, 'Car id was not specified');
-
     req.body.carId = +carId;
-    return next();
+    return req.body.carId
+        ? next()
+        : errorMessage(res, 422, 'invalid car id');
 };
 
 const validateFlag = [validateCarId, validateReason, validateDescription];

--- a/server/models/db/queries.js
+++ b/server/models/db/queries.js
@@ -132,3 +132,16 @@ export const orderQueries = {
         return rows[0];
     }
 };
+
+
+export const createFlag = async (carId, reason, description, reportedBy) => {
+    const queryString = {
+        text: `INSERT INTO flags
+            (car_id, reason, description, reported_by)
+            VALUES ($1, $2, $3, $4)
+            RETURNING *;`,
+        values: [carId, reason, description, reportedBy]
+    };
+    const { rows } = await pool.query(queryString);
+    return rows[0];
+};

--- a/server/routes/flag.js
+++ b/server/routes/flag.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import flagAd from '../controllers/flag';
+import { verifyToken } from '../middleware/jwtAuth';
+import validateFlag from '../middleware/vaidators/flag';
+
+const router = express.Router();
+
+router.post('/flag', verifyToken, validateFlag, flagAd);
+
+export default router;

--- a/server/test/controllerTest/flag.test.js
+++ b/server/test/controllerTest/flag.test.js
@@ -1,0 +1,173 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../../app';
+
+const { expect } = chai;
+
+chai.use(chaiHttp);
+
+let userToken;
+
+before((done) => {
+    chai.request(app)
+        .post('/api/v2/auth/signin')
+        .send({
+            email: 'ricardokaka@gmail.com',
+            password: 'pass'
+        })
+        .end((error, res) => {
+            if (error) done(error);
+            userToken = res.body.data.token;
+            done();
+        });
+});
+
+
+describe('POST /api/v2/flag', () => {
+    it('should return a 422 status if carId was not provided', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                reason: 'pricing'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Car id was not specified');
+                done();
+            });
+    });
+
+    it('should return a 404 status if car does not exist', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 300,
+                reason: 'pricing'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(404);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('car not found');
+                done();
+            });
+    });
+
+    it('should return a 422 status error if carId is not an integer', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 'notInteger',
+                reason: 'pricing'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('invalid car id');
+                done();
+            });
+    });
+
+    it('should return a 422 status error if reason was not specified', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 4,
+                description: 'super weird reason'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Reason was not specified');
+                done();
+            });
+    });
+
+    it('should return a 422 status error if reason is longer than 100 characters', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 4,
+                reason: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Turpis massa sed elementum tempus egestas. Enim nec dui nunc mattis. Sapien eget mi proin sed libero.',
+                description: 'super weird reason'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Reason should not exxceed 100 characters');
+                done();
+            });
+    });
+
+    it('should return a 422 status error if reason is an integer', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 4,
+                reason: 4949,
+                description: 'super weird reason'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Invalid reason');
+                done();
+            });
+    });
+
+    it('should return a 422 status error if description is an integer', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 4,
+                reason: 'Weird pricing',
+                description: 299
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(422);
+                expect(res.body.status).to.deep.equal('error');
+                expect(res.body.message).to.deep.equal('Invalid description');
+                done();
+            });
+    });
+
+    it('should return a 201 status if everything checks out', (done) => {
+        chai.request(app)
+            .post('/api/v2/flag')
+            .send({
+                carId: 4,
+                reason: 'Weird pricing',
+                description: 'It really feels weird'
+            })
+            .set('Authorization', userToken)
+            .end((error, res) => {
+                if (error) done(error);
+                expect(res).to.be.an('object');
+                expect(res).to.have.status(201);
+                expect(res.body.status).to.deep.equal('success');
+                expect(res.body.data).to.be.an('object');
+                done();
+            });
+    });
+});


### PR DESCRIPTION
### What does this PR do?
- Creates the API endpoint `POST /api/v2/flag` to flag/report a fraudulent ads

### Description of tasks to be completed
- Test API endpoint
- Write controller logic for users to report fraudulent ads

### How should this be manually tested?
- Clone or download this repository
- Run `git checkout ft-apiv2-flag-ad-166718236`
- Set the environment variables as seen in the `/server/config/app.config.js` file
##### To test just this api run:
```
npm run db:populate && mocha ./server/test/controllerTest/flag.test.js --require @babel/polyfill --require babel/register  --no-timeout --exit
```
##### To test the entire app,
- Run `npm test`

#### Testing API with Postman
- Clone or download this repository
- Run `git checkout ft-apiv2-flag-ad-166718236`
- Run `npm run dev-start`
- Send a `POST` request to `localhost:3000/api/v2/flag` with the following json values:
```
{
  "carId": Integer,
  "reason": String,
  "description": String (optional)
}
```

### Any background context you want to provide?
- You need to be logged in to test this application on Postman.
   - send a `POST` request to `localhost:3000/api/v2/auth/sign` using the following credentials:
 ``` 
      {
        "email": "ricardokaka@gmail.com",
        "password": "pass"
      }
```
   - A token will be generated and send via the response data.
   - Set the `Authorization` header of the `POST` request to  `localhost:3000/api/v2/flag`

### What are the relevant Pivotal Tracker stories?
-  [#166718236](https://www.pivotaltracker.com/story/show/166718236)