### PR TITLE
Create API endpoint to get cars based on specific properties

### DIFF
--- a/server/controllers/car.js
+++ b/server/controllers/car.js
@@ -85,11 +85,20 @@ export const getSpecificCar = async (req, res) => {
     }
 };
 
-const getAvailableCars = async (req, res) => {
-    const isInvalidStatus = (req.query.status !== 'available');
+export const getAvailableCars = async (req, res) => {
+    const {
+        status,
+        min_price: min = 0,
+        max_price: max = 2147483647,
+        state = '%',
+        body_type: bodyType = '%',
+        make = '%'
+    } = req.query;
+    const isInvalidStatus = (status !== 'available');
     if (isInvalidStatus) return errorMessage(res, 403, 'you do not have access to this resource');
     try {
-        const cars = await carQueries.findAvailableCars();
+        const cars = await carQueries
+            .findAvailableCars(min, max, state, bodyType, make);
         return cars.length
             ? res.status(200).json({
                 status: 'success',

--- a/server/models/db/queries.js
+++ b/server/models/db/queries.js
@@ -71,10 +71,13 @@ export const carQueries = {
         return rows[0];
     },
 
-    async findAvailableCars() {
+    async findAvailableCars(min, max, state, bodyType, make) {
         const queryString = {
-            text: 'SELECT * FROM cars WHERE status=$1;',
-            values: ['available']
+            text: `SELECT * FROM cars
+                WHERE status=$1 AND (price BETWEEN $2 AND $3) 
+                AND state ILIKE $4 AND
+                body_type ILIKE $5 AND manufacturer ILIKE $6;`,
+            values: ['available', min, max, state, bodyType, make]
         };
         const { rows } = await pool.query(queryString);
         return rows;


### PR DESCRIPTION
### What does this PR do?
Creates the API endpoint:
```
GET /api/v2/car?status=available&min_price=XXXvalue&max_price=XXXvalue
```
 This endpoint gets cars based on specific properties described in the request query: 
```
status (defaults to 'available')
body_type
make
state
min_price and max_price
````

### Description of tasks to be completed
- Test API endpoint
- Write controller logic to get cars based n properties provided in the request query

### How should this be manually tested?
- Clone or download this repository
- Run `git checkout ft-apiv2-filter-cars`
- Set the environment variables listed in the `/server/config/app.config.js` file

##### To test just this api endpoint and other api endpoints associated with cars run:
```
npm run db:populate && mocha ./server/test/controllerTest/car.test.js --require @babel/polyfill --require babel/register  --no-timeout --exit
```
##### To test the entire app,
- Run `npm test`

#### Testing API with Postman
After you have cloned and set the environment variables as described above,
- Run `npm run dev-start`
- Send a `GET` request to `localhost:3000/api/v1/car` and set a combination of any of the following query parameter:
```
status: 'available' (mandatory)
body_type: String (optional)
make: String (optional)
state: String (optional)
min_price and max_price: Integer (optional)
````


### Any background context you want to provide?
- In a bid to deliver this project quickly, this PR handles four pivotal tracker stories because all the functionalities could be written at once:
   - One SQL query can handle all the queries.
   - One controller function can also handle all the requests.
 Therefore, creating new branches for each query seemed redundant.

- You do not need to be logged to apply queries to this API endpoint

### What are the relevant Pivotal Tracker stories?
- [#166724861](https://www.pivotaltracker.com/story/show/166724861) : queries `state` of cars (new)
- [#166724883](https://www.pivotaltracker.com/story/show/166724883) : queries `state` of cars (used)
- [#166724919](https://www.pivotaltracker.com/story/show/166724919) : queries `make` (manufacturer) of cars
- [#166724932](https://www.pivotaltracker.com/story/show/166724932) : queries `body_type` of cars
